### PR TITLE
Jelly: Remove the SwipeRefreshLayout

### DIFF
--- a/app/src/main/java/org/lineageos/jelly/MainActivity.java
+++ b/app/src/main/java/org/lineageos/jelly/MainActivity.java
@@ -43,8 +43,6 @@ import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
-import android.support.v4.view.GestureDetectorCompat;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.view.menu.MenuBuilder;
@@ -54,11 +52,9 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.ContextThemeWrapper;
-import android.view.GestureDetector;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
@@ -91,8 +87,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-public class MainActivity extends WebViewExtActivity implements View.OnTouchListener,
-        View.OnScrollChangeListener, SearchBarController.OnCancelListener {
+public class MainActivity extends WebViewExtActivity implements
+         SearchBarController.OnCancelListener {
     private static final String TAG = MainActivity.class.getSimpleName();
     private static final String PROVIDER = "org.lineageos.jelly.fileprovider";
     private static final String EXTRA_INCOGNITO = "extra_incognito";
@@ -131,10 +127,6 @@ public class MainActivity extends WebViewExtActivity implements View.OnTouchList
 
     private Bitmap mUrlIcon;
 
-    private SwipeRefreshLayout mSwipeRefreshLayout;
-    private GestureDetectorCompat mGestureDetector;
-    private boolean mFingerReleased = false;
-    private boolean mGestureOngoing = false;
     private boolean mIncognito;
 
     private View mCustomView;
@@ -152,11 +144,6 @@ public class MainActivity extends WebViewExtActivity implements View.OnTouchList
         setSupportActionBar(toolbar);
 
         mCoordinator = (CoordinatorLayout) findViewById(R.id.coordinator_layout);
-        mSwipeRefreshLayout = (SwipeRefreshLayout) findViewById(R.id.swipe_refresh);
-        mSwipeRefreshLayout.setOnRefreshListener(() -> {
-            mWebView.reload();
-            new Handler().postDelayed(() -> mSwipeRefreshLayout.setRefreshing(false), 1000);
-        });
         mLoadingProgress = (ProgressBar) findViewById(R.id.load_progress);
         AutoCompleteTextView autoCompleteTextView =
                 (AutoCompleteTextView) findViewById(R.id.url_bar);
@@ -223,17 +210,6 @@ public class MainActivity extends WebViewExtActivity implements View.OnTouchList
         mWebView.loadUrl(url == null ? PrefsUtils.getHomePage(this) : url);
 
         mHasThemeColorSupport = WebViewCompat.isThemeColorSupported(mWebView);
-
-        mGestureDetector = new GestureDetectorCompat(this,
-                new GestureDetector.SimpleOnGestureListener() {
-                    @Override
-                    public boolean onDoubleTapEvent(MotionEvent e) {
-                        mGestureOngoing = true;
-                        return false;
-                    }
-                });
-        mWebView.setOnTouchListener(this);
-        mWebView.setOnScrollChangeListener(this);
 
         mSearchController = new SearchBarController(mWebView,
                 (EditText) findViewById(R.id.search_menu_edit),
@@ -663,7 +639,7 @@ public class MainActivity extends WebViewExtActivity implements View.OnTouchList
         addContentView(mCustomView, new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         findViewById(R.id.app_bar_layout).setVisibility(View.GONE);
-        mSwipeRefreshLayout.setVisibility(View.GONE);
+        findViewById(R.id.web_view_container).setVisibility(View.VISIBLE);
     }
 
     @Override
@@ -674,7 +650,7 @@ public class MainActivity extends WebViewExtActivity implements View.OnTouchList
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         setImmersiveMode(false);
         findViewById(R.id.app_bar_layout).setVisibility(View.VISIBLE);
-        mSwipeRefreshLayout.setVisibility(View.VISIBLE);
+        findViewById(R.id.web_view_container).setVisibility(View.GONE);
         ViewGroup viewGroup = (ViewGroup) mCustomView.getParent();
         viewGroup.removeView(mCustomView);
         mFullScreenCallback.onCustomViewHidden();
@@ -700,40 +676,6 @@ public class MainActivity extends WebViewExtActivity implements View.OnTouchList
         launcherIcon.recycle();
         Snackbar.make(mCoordinator, getString(R.string.shortcut_added),
                 Snackbar.LENGTH_LONG).show();
-    }
-
-    @Override
-    public boolean onTouch(View v, MotionEvent event) {
-        mGestureDetector.onTouchEvent(event);
-        mFingerReleased = event.getAction() == MotionEvent.ACTION_UP;
-
-        if (mGestureOngoing && mFingerReleased && mWebView.getScrollY() == 0) {
-            // We are ending a gesture and we are at the top
-            mSwipeRefreshLayout.setEnabled(true);
-        } else if (mGestureOngoing || event.getPointerCount() > 1) {
-            // A gesture is ongoing or starting
-            mSwipeRefreshLayout.setEnabled(false);
-        } else if (event.getAction() != MotionEvent.ACTION_MOVE) {
-            // We are either initiating or ending a movement
-            if (mWebView.getScrollY() == 0) {
-                mSwipeRefreshLayout.setEnabled(true);
-            } else {
-                mSwipeRefreshLayout.setEnabled(false);
-            }
-        }
-        // Reset the flag, the gesture detector will set it to true if the
-        // gesture is still ongoing
-        mGestureOngoing = false;
-
-        return super.onTouchEvent(event);
-    }
-
-    @Override
-    public void onScrollChange(View v, int scrollX, int scrollY, int oldScrollX, int oldScrollY) {
-        // In case we reach the top without touching the screen (e.g. fling gesture)
-        if (mFingerReleased && scrollY == 0) {
-            mSwipeRefreshLayout.setEnabled(true);
-        }
     }
 
     private void setImmersiveMode(boolean enable) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -65,8 +65,8 @@
         </android.support.v7.widget.Toolbar>
     </android.support.design.widget.AppBarLayout>
 
-    <android.support.v4.widget.SwipeRefreshLayout
-        android:id="@+id/swipe_refresh"
+    <FrameLayout
+        android:id="@+id/web_view_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?actionBarSize">
@@ -75,5 +75,5 @@
             android:id="@+id/web_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </FrameLayout>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
This is just causing issues. Some webpages make the SwipeRefreshLayout
intercept all the downwards swipes, triggering an unwanted page
refresh rather than scrolling the content of the page. This appears
to happen with pages that have a computeVerticalScrollRange() equals
to their getHeight(). However checking these two values is not enough
for some pages that generate content dynamically. Let's just get rid
of the SwipeRefreshLayout and all the related hacks.

Change-Id: I172cdc310cd86d1cd0d0f400930bd41c2da34818